### PR TITLE
fix(tests): Move tests to dedicated namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\": "tests/"
+            "Miquido\\RequestDataCollector\\Collectors\\GuzzleCollector\\Tests\\": "tests/"
         }
     },
     "scripts": {

--- a/tests/Guzzle6ClientDecoratorTest.php
+++ b/tests/Guzzle6ClientDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Tests\Collectors\GuzzleCollector;
+namespace Miquido\RequestDataCollector\Collectors\GuzzleCollector\Tests;
 
 use GuzzleHttp\ClientInterface;
 use Miquido\RequestDataCollector\Collectors\GuzzleCollector\Guzzle6ClientDecorator;

--- a/tests/GuzzleCollectorTest.php
+++ b/tests/GuzzleCollectorTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Tests\Collectors\GuzzleCollector;
+namespace Miquido\RequestDataCollector\Collectors\GuzzleCollector\Tests;
 
 use Illuminate\Contracts\Container\Container;
 use Miquido\RequestDataCollector\Collectors\GuzzleCollector\GuzzleCollector;


### PR DESCRIPTION
Move tests to dedicated namespace so that they don't interfere with others.

Also fixes Composer 2.0 deprecations:
```
Deprecation Notice: Class Tests\Collectors\GuzzleCollector\Guzzle6ClientDecoratorTest located in ./tests/Guzzle6ClientDecoratorTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer.phar/src/Composer/Autoload/ClassMapGenerator.php:185
Deprecation Notice: Class Tests\Collectors\GuzzleCollector\GuzzleCollectorTest located in ./tests/GuzzleCollectorTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer.phar/src/Composer/Autoload/ClassMapGenerator.php:185
```