### PR TITLE
fix(GuzzleCollector): Abstract name is not passed

### DIFF
--- a/src/GuzzleCollector.php
+++ b/src/GuzzleCollector.php
@@ -94,9 +94,10 @@ class GuzzleCollector implements DataCollectorInterface, ConfigurableInterface, 
         }
 
         foreach ($abstractsMap as ['abstract' => $abstract, 'type' => $type, 'oldInstance' => $instance]) {
-            $container->{$type}($abstract, function () use ($container, $instance): object {
+            $container->{$type}($abstract, function () use ($container, $instance, &$abstract): object {
                 return $container->make($this->config['decorate']['with'], [
-                    'client' => $instance,
+                    'client'   => $instance,
+                    'abstract' => $abstract,
                 ]);
             });
         }

--- a/tests/GuzzleCollectorTest.php
+++ b/tests/GuzzleCollectorTest.php
@@ -799,12 +799,13 @@ class GuzzleCollectorTest extends TestCase
             ->shouldBeCalledOnce()
             ->will(function (array $args, $containerProphecy) use ($self, $object): object {
                 /**
+                 * @var string                                                                      $abstract
                  * @var callable                                                                    $concrete
                  * @var \Illuminate\Contracts\Container\Container|\Prophecy\Prophecy\ObjectProphecy $containerProphecy
                  */
-                [, $concrete] = $args;
+                [$abstract, $concrete] = $args;
 
-                $containerProphecy->make('decorator::class', ['client' => $object])
+                $containerProphecy->make('decorator::class', ['client' => $object, 'abstract' => $abstract])
                     ->shouldBeCalledOnce()
                     ->willReturn($self->prophesize(stdClass::class)->reveal());
 


### PR DESCRIPTION
Abstract name is not passed when creating Guzzle decorator instance.