### PR TITLE
ci(travis): update Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
-sudo: false
+os: linux
+dist: xenial
 
 git:
   depth: 1
@@ -14,20 +15,19 @@ php:
   - '7.4'
   - master
 
-matrix:
+jobs:
   fast_finish: true
   allow_failures:
     - php: master
 
 env:
-  matrix:
+  jobs:
     - DEPENDENCIES="highest"
     - DEPENDENCIES="lowest"
   global:
     - DEFAULT_COMPOSER_FLAGS="--no-interaction --no-ansi --no-progress --no-suggest --no-scripts --optimize-autoloader --classmap-authoritative"
 
 install:
-  - composer global require "hirak/prestissimo:^0.3" --prefer-dist --no-progress --no-suggest --classmap-authoritative --ansi
   - if [[ "$DEPENDENCIES" = 'highest' ]]; then composer update $DEFAULT_COMPOSER_FLAGS; fi
   - if [[ "$DEPENDENCIES" = 'lowest' ]]; then composer update $DEFAULT_COMPOSER_FLAGS --prefer-lowest; fi
 
@@ -37,7 +37,7 @@ before_script:
 script:
   - composer cs-check
   - composer code-analyse
-  - phpunit --bootstrap vendor/autoload.php --configuration phpunit.xml
+  - phpunit --configuration phpunit.xml
 
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "miquido/request-data-collector-elasticsearch": "Allows collecting Elasticsearch requests"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.16.1",
+        "friendsofphp/php-cs-fixer": "^2.16.7",
         "jangregor/phpstan-prophecy": "^0.6",
         "phpstan/phpstan": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",


### PR DESCRIPTION
Update Travis configuration according to warnings.

```
Build config validation:
root: deprecated key sudo (The key `sudo` has no effect anymore.)
root: missing dist, using the default xenial
root: missing os, using the default linux
env: key matrix is an alias for jobs, using jobs
root: key matrix is an alias for jobs, using jobs
```